### PR TITLE
Default Kustomize args to > v4

### DIFF
--- a/kustomize.go
+++ b/kustomize.go
@@ -143,15 +143,15 @@ func (r *Runner) KustomizeBuild(srcDir string, tempDir string, opts ...Kustomize
 		r.Logf("Failed to parse `kustomize version` output: %v\nFalling-back to the kustomize v4 mode...", err)
 	}
 
-	if major > 3 {
-		kustomizeArgs = append(kustomizeArgs, "--load-restrictor=LoadRestrictionsNone")
-		if u.EnableAlphaPlugins {
-			kustomizeArgs = append(kustomizeArgs, "--enable-alpha-plugins")
-		}
-	} else {
+	if major <= 3 {
 		kustomizeArgs = append(kustomizeArgs, "--load_restrictor=none")
 		if u.EnableAlphaPlugins {
 			kustomizeArgs = append(kustomizeArgs, "--enable_alpha_plugins")
+		}
+	} else {
+		kustomizeArgs = append(kustomizeArgs, "--load-restrictor=LoadRestrictionsNone")
+		if u.EnableAlphaPlugins {
+			kustomizeArgs = append(kustomizeArgs, "--enable-alpha-plugins")
 		}
 	}
 


### PR DESCRIPTION
If the version parsing fails for whatever reason, the current behavior defaults to version 3 args or below. This PR makes a change to default to version 4 style args in the event of a failed parse.

Given that newer versions are likely to have the same behavior as v4, it makes sense to default to version 4 arg style in that case. There is even a line that specifies this intent on L143 of the same file.

resolves #35 