### PR TITLE
Fix kustomize bases relative path

### DIFF
--- a/kustomize.go
+++ b/kustomize.go
@@ -93,7 +93,13 @@ func (r *Runner) KustomizeBuild(srcDir string, tempDir string, opts ...Kustomize
 	if err != nil {
 		return "", err
 	}
-	relPath, err := filepath.Rel(evaluatedPath, path.Join(prevDir, srcDir))
+	var absoluteSrcPath string
+	if filepath.IsAbs(srcDir) {
+		absoluteSrcPath = srcDir
+	} else {
+		absoluteSrcPath = path.Join(prevDir, srcDir)
+	}
+	relPath, err := filepath.Rel(evaluatedPath, absoluteSrcPath)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
As I was trying to install an OperatorSDK project using Helmfile, I found that there was an error when setting the chart to a git repository in Helmfile. Helmfile clones the repository in a directory not relative to the current execution. Therefore, at the moment of charitfying the customization, Kustomize fails, because it can't find the source directory. As I traced the error, I found that the issue is that when generating the relative path, `KustomizeBuild` prepends the current working directory to the absolute path, which makes it fail.

I tested with the helmfile from https://github.com/helmfile/helmfile/blob/main/test/advanced/helmfile.yaml#L6-L9, replaced `kustomchart`'s chart with the repository reference:

```yaml
...
releases:
- name: kustomapp
  chart: git::https://github.com/helmfile/helmfile.git@test/advanced/kustomapp?ref=main
  values:
  - namePrefix: kustomapp-
...
```

And it fails with the following error:

```
Generating /tmp/chartify868461553/raw1/raw/all.patched.yaml
running kustomize build /tmp/chartify868461553/raw1/raw --output /tmp/chartify868461553/raw1/raw/all.patched.yaml
Detected 1 resources and 0 CRDs
Removing /tmp/chartify868461553/raw1/raw/templates
Removing /tmp/chartify868461553/raw1/raw/charts
Removing /tmp/chartify868461553/raw1/raw/crds
Removing /tmp/chartify868461553/raw1/raw/strategicmergepatches
Removing /tmp/chartify868461553/raw1/raw/kustomization.yaml
Removing /tmp/chartify868461553/raw1/raw/all.patched.yaml
Removed /tmp/helmfile922195940/raw1-values-75db555c7d
Removed /tmp/helmfile1017844770/raw1-values-575db5854
err: [exit status 1

COMMAND:
  kustomize -o /tmp/chartify790914951/kustomapp/templates/kustomized.yaml build --load-restrictor=LoadRestrictionsNone --enable-alpha-plugins /tmp/chartify790914951/kustomapp

OUTPUT:
  Error: accumulating resources: accumulation err='accumulating resources from '../../../home/ivan/Code/Devops/helmfile/test/advanced/home/ivan/.cache/helmfile/kustomapp/https_github_com_helmfile_helmfile_git.ref=main/test/advanced/kustomapp': open /home/ivan/Code/Devops/helmfile/test/advanced/home/ivan/.cache/helmfile/kustomapp/https_github_com_helmfile_helmfile_git.ref=main/test/advanced/kustomapp: no such file or directory': must build at directory: not a valid directory: evalsymlink failure on '/home/ivan/Code/Devops/helmfile/test/advanced/home/ivan/.cache/helmfile/kustomapp/https_github_com_helmfile_helmfile_git.ref=main/test/advanced/kustomapp' : lstat /home/ivan/Code/Devops/helmfile/test/advanced/home: no such file or directory]
changing working directory back to "/home/ivan/Code/Devops/helmfile/test/advanced"
in ./helmfile.yaml: [exit status 1

COMMAND:
  kustomize -o /tmp/chartify790914951/kustomapp/templates/kustomized.yaml build --load-restrictor=LoadRestrictionsNone --enable-alpha-plugins /tmp/chartify790914951/kustomapp

OUTPUT:
  Error: accumulating resources: accumulation err='accumulating resources from '../../../home/ivan/Code/Devops/helmfile/test/advanced/home/ivan/.cache/helmfile/kustomapp/https_github_com_helmfile_helmfile_git.ref=main/test/advanced/kustomapp': open /home/ivan/Code/Devops/helmfile/test/advanced/home/ivan/.cache/helmfile/kustomapp/https_github_com_helmfile_helmfile_git.ref=main/test/advanced/kustomapp: no such file or directory': must build at directory: not a valid directory: evalsymlink failure on '/home/ivan/Code/Devops/helmfile/test/advanced/home/ivan/.cache/helmfile/kustomapp/https_github_com_helmfile_helmfile_git.ref=main/test/advanced/kustomapp' : lstat /home/ivan/Code/Devops/helmfile/test/advanced/home: no such file or directory]
```

Note the path:
```
../../../home/ivan/Code/Devops/helmfile/test/advanced/home/ivan/.cache/helmfile/kustomapp/https_github_com_helmfile_helmfile_git.ref=main/test/advanced/kustomapp'
```

Which is declared on the bases of the generated `kustomization.yaml`. By inspecting the temp YAML, these are the contents:

```yaml
bases:
- ../../../home/ivan/Code/Devops/helmfile/test/advanced/home/ivan/.cache/helmfile/kustomapp/https_github_com_ivanvc_dispatcher_git.ref=main/config/crd
```

---

So, this PR addresses this issue, by prepending the current working directory to the bases path, just if the source directory `srcDir` is not absolute. If the passed `srcDir` is absolute, it won't prepend the working directory, and will just generate the relative reference to that file.