### PR TITLE
feat: impl patch with alpha plugin flag.

### DIFF
--- a/chartify.go
+++ b/chartify.go
@@ -444,6 +444,7 @@ func (r *Runner) Chartify(release, dirOrChart string, opts ...ChartifyOption) (s
 			JsonPatches:           u.JsonPatches,
 			StrategicMergePatches: u.StrategicMergePatches,
 			Transformers:          u.Transformers,
+			EnableAlphaPlugins:    u.EnableKustomizeAlphaPlugins,
 		}
 		if err := r.Patch(tempDir, generatedManifestFiles, patchOpts); err != nil {
 			return "", err

--- a/integration_test.go
+++ b/integration_test.go
@@ -300,6 +300,29 @@ func TestIntegration(t *testing.T) {
 			},
 		},
 	})
+
+	// SAVE_SNAPSHOT=1 go1.20 test -run ^TestIntegration/kube_manifest_transformer_alpha_plugin$ ./
+	runTest(t, integrationTestCase{
+		description: "kube_manifest_transformer_alpha_plugin",
+		release:     "myapp",
+		chart:       "./testdata/kube_manifest_yml",
+		opts: ChartifyOpts{
+			AdhocChartDependencies: []ChartDependency{
+				{
+					Alias:   "log",
+					Chart:   repo + "/log",
+					Version: "0.1.0",
+				},
+			},
+			Transformers: []string{
+				"./testdata/kube_manifest_transformer_alpha_plugin/annotations.yaml",
+			},
+			SetFlags: []string{
+				"--set", "log.enabled=true",
+			},
+			EnableKustomizeAlphaPlugins: true,
+		},
+	})
 }
 
 func setupHelmConfig(t *testing.T) {

--- a/testdata/integration/testcases/kube_manifest_transformer_alpha_plugin/want
+++ b/testdata/integration/testcases/kube_manifest_transformer_alpha_plugin/want
@@ -1,0 +1,100 @@
+---
+# Source: kube_manifest_yml/templates/patched_resources.yaml
+apiVersion: v1
+data:
+  bar: |
+    -----BEGIN CERTIFICATE-----
+    FOO
+    -----END CERTIFICATE-----
+  foo: bar
+kind: ConfigMap
+metadata:
+  annotations:
+    app: myApp
+    greeting/morning: a string with blanks
+  name: myconfig1
+---
+# Source: kube_manifest_yml/templates/patched_resources.yaml
+apiVersion: v1
+data:
+  bar: |
+    -----BEGIN CERTIFICATE-----
+    FOO
+    -----END CERTIFICATE-----
+  foo: bar
+kind: ConfigMap
+metadata:
+  annotations:
+    app: myApp
+    greeting/morning: a string with blanks
+  name: myconfig2
+---
+# Source: kube_manifest_yml/templates/patched_resources.yaml
+apiVersion: v1
+data:
+  baz: |
+    -----BEGIN CERTIFICATE-----
+    FOO
+    -----END CERTIFICATE-----
+  foo: baz
+kind: ConfigMap
+metadata:
+  annotations:
+    app: myApp
+    greeting/morning: a string with blanks
+  name: myconfig3
+---
+# Source: kube_manifest_yml/templates/patched_resources.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    app: myApp
+    greeting/morning: a string with blanks
+  labels:
+    app.kubernetes.io/instance: myapp
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: log
+    app.kubernetes.io/version: 1.16.0
+    helm.sh/chart: log-0.1.0
+  name: myapp-log
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: myapp
+      app.kubernetes.io/name: log
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: myapp
+        app.kubernetes.io/name: log
+    spec:
+      containers:
+      - image: nginx:1.16.0
+        name: log
+---
+# Source: kube_manifest_yml/templates/patched_resources.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    app: myApp
+    greeting/morning: a string with blanks
+    helm.sh/hook: test
+  labels:
+    app.kubernetes.io/instance: myapp
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: log
+    app.kubernetes.io/version: 1.16.0
+    helm.sh/chart: log-0.1.0
+  name: myapp-log-test-connection
+spec:
+  containers:
+  - args:
+    - myapp-log:80
+    command:
+    - wget
+    image: busybox
+    name: wget
+  restartPolicy: Never

--- a/testdata/kube_manifest_transformer_alpha_plugin/annotations.yaml
+++ b/testdata/kube_manifest_transformer_alpha_plugin/annotations.yaml
@@ -1,0 +1,10 @@
+apiVersion: builtin
+kind: AnnotationsTransformer
+metadata:
+  name: not-important-to-example
+annotations:
+  app: myApp
+  greeting/morning: a string with blanks
+fieldSpecs:
+- path: metadata/annotations
+  create: true


### PR DESCRIPTION
## Purpose

feat: impl patch with alpha plugin flag. More information is here: https://github.com/helmfile/helmfile/discussions/827

I found that the helmfile HelmState structure passed `chartifyOpts.EnableKustomizeAlphaPlugins=true` to `chartify`, but it did not take effect in `chartify`.

### Tests

For transformer and alpha plugin, I have added a integration test using the `AnnotationsTransformer` kustomize plugin

+ integration_test.go

