### PR TITLE
feat: add an option to set a custom kustomize binary

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -58,18 +58,24 @@ func WithLogf(logf func(string, ...interface{})) Option {
 	}
 }
 
+func KustomizeBin(b string) Option {
+	return func(r *Runner) error {
+		r.KustomizeBinary = b
+		return nil
+	}
+}
+
 func New(opts ...Option) *Runner {
 	r := &Runner{
-		KustomizeBinary: "",
-		RunCommand:      RunCommand,
-		CopyFile:        CopyFile,
-		WriteFile:       os.WriteFile,
-		ReadFile:        os.ReadFile,
-		ReadDir:         os.ReadDir,
-		Walk:            filepath.Walk,
-		Exists:          exists,
-		Logf:            printf,
-		MakeTempDir:     makeTempDir,
+		RunCommand:  RunCommand,
+		CopyFile:    CopyFile,
+		WriteFile:   os.WriteFile,
+		ReadFile:    os.ReadFile,
+		ReadDir:     os.ReadDir,
+		Walk:        filepath.Walk,
+		Exists:      exists,
+		Logf:        printf,
+		MakeTempDir: makeTempDir,
 	}
 
 	for i := range opts {


### PR DESCRIPTION
- Added `KustomizeBin` option to set a custom kustomize binary.
- Removed `KustomizeBinary` string value on `New` function because in Go strings are empty by default.