### PR TITLE
feat: use helmBin() for kustomize build for helmChart in kustomization.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *~
 .idea
+
+# testdata
+testdata/kustomize_with_helm_charts/charts/

--- a/chartify.go
+++ b/chartify.go
@@ -251,14 +251,15 @@ func (r *Runner) Chartify(release, dirOrChart string, opts ...ChartifyOption) (s
 	generatedManifestsUnderTemplatesDir := []string{}
 
 	if isKustomization {
-		kustomOpts := &KustomizeBuildOpts{
+		kustomizeOpts := &KustomizeBuildOpts{
 			ValuesFiles:        u.ValuesFiles,
 			SetValues:          u.SetValues,
 			SetFlags:           u.SetFlags,
 			EnableAlphaPlugins: u.EnableKustomizeAlphaPlugins,
 			Namespace:          u.Namespace,
+			HelmBinary:         r.helmBin(),
 		}
-		kustomizeFile, err := r.KustomizeBuild(dirOrChart, tempDir, kustomOpts)
+		kustomizeFile, err := r.KustomizeBuild(dirOrChart, tempDir, kustomizeOpts)
 		if err != nil {
 			return "", err
 		}

--- a/kustomize.go
+++ b/kustomize.go
@@ -44,6 +44,7 @@ type KustomizeBuildOpts struct {
 	SetFlags           []string
 	EnableAlphaPlugins bool
 	Namespace          string
+	HelmBinary         string
 }
 
 func (o *KustomizeBuildOpts) SetKustomizeBuildOption(opts *KustomizeBuildOpts) error {
@@ -153,7 +154,7 @@ func (r *Runner) KustomizeBuild(srcDir string, tempDir string, opts ...Kustomize
 	if err != nil {
 		return "", err
 	}
-	kustomizeArgs = append(kustomizeArgs, f)
+	kustomizeArgs = append(kustomizeArgs, f, "--enable-helm", "--helm-command="+u.HelmBinary)
 
 	out, err := r.runInDir(tempDir, r.kustomizeBin(), append(kustomizeArgs, tempDir)...)
 	if err != nil {

--- a/kustomize.go
+++ b/kustomize.go
@@ -154,7 +154,11 @@ func (r *Runner) KustomizeBuild(srcDir string, tempDir string, opts ...Kustomize
 	if err != nil {
 		return "", err
 	}
-	kustomizeArgs = append(kustomizeArgs, f, "--enable-helm", "--helm-command="+u.HelmBinary)
+	kustomizeArgs = append(kustomizeArgs, f, "--enable-helm")
+
+	if u.HelmBinary != "" {
+		kustomizeArgs = append(kustomizeArgs, "--helm-command="+u.HelmBinary)
+	}
 
 	out, err := r.runInDir(tempDir, r.kustomizeBin(), append(kustomizeArgs, tempDir)...)
 	if err != nil {

--- a/testdata/integration/testcases/kustomize_with_helm_charts/want
+++ b/testdata/integration/testcases/kustomize_with_helm_charts/want
@@ -1,0 +1,25 @@
+
+---
+# Source: kustomize_with_helm_charts/templates/kustomized.yaml
+# Source: kustomize_with_helm_charts/templates/kustomized.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    helm.sh/hook: test
+  labels:
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: log
+    app.kubernetes.io/version: 1.16.0
+    helm.sh/chart: log-0.1.0
+  name: release-name-log-test-connection
+spec:
+  containers:
+  - args:
+    - release-name-log:80
+    command:
+    - wget
+    image: busybox
+    name: wget
+  restartPolicy: Never

--- a/testdata/kustomize_with_helm_charts/kustomization.yaml
+++ b/testdata/kustomize_with_helm_charts/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+helmCharts:
+  - repo: http://localhost:18080/
+    name: log
+    version: 0.1.0


### PR DESCRIPTION
This adds support --helm-binary for helmChart in kustomization.yaml by:

- Changing use helmBin() for kustomize build

Resolves https://github.com/helmfile/helmfile/issues/1121