### PR TITLE
chore: use patches instead of deprecated patchesJson6902

### DIFF
--- a/patch.go
+++ b/patch.go
@@ -55,7 +55,7 @@ resources:
 	}
 
 	if len(u.JsonPatches) > 0 {
-		kustomizationYamlContent += `patchesJson6902:
+		kustomizationYamlContent += `patches:
 `
 		for i, f := range u.JsonPatches {
 			fileBytes, err := r.ReadFile(f)


### PR DESCRIPTION
## Context

`patchesJson6902` directive has been deprecated on kustomize. 
`patches` is the replacement. 

The difference is explained [here](https://github.com/kubernetes-sigs/kustomize/issues/2705#issuecomment-659012281)
No Breaking change AFAIK 