### PR TITLE
chore: update golang-ci lint version

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,4 +25,4 @@ jobs:
       - name: Golangci lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.56.1
+          version: v1.60.1


### PR DESCRIPTION
https://github.com/golangci/golangci-lint/releases/tag/v1.60.1