### PR TITLE
Revert "chore: use patches instead of deprecated patchesJson6902"

### DIFF
--- a/patch.go
+++ b/patch.go
@@ -55,7 +55,7 @@ resources:
 	}
 
 	if len(u.JsonPatches) > 0 {
-		kustomizationYamlContent += `patches:
+		kustomizationYamlContent += `patchesJson6902:
 `
 		for i, f := range u.JsonPatches {
 			fileBytes, err := r.ReadFile(f)


### PR DESCRIPTION
Reverts helmfile/chartify#84

https://github.com/helmfile/chartify/issues/94