### PR TITLE
feat: Adding template arguments

### DIFF
--- a/chartify.go
+++ b/chartify.go
@@ -113,6 +113,9 @@ type ChartifyOpts struct {
 	TemplateFuncs template.FuncMap
 	// TemplateData is the data available via {{ . }} within .gotmpl files
 	TemplateData interface{}
+
+	// TemplateArgs to pass Flags to helm template
+	TemplateArgs string
 }
 
 type ChartifyOption interface {
@@ -401,6 +404,7 @@ func (r *Runner) Chartify(release, dirOrChart string, opts ...ChartifyOption) (s
 		Validate:     u.Validate,
 		KubeVersion:  u.KubeVersion,
 		ApiVersions:  u.ApiVersions,
+		TemplateArgs: u.TemplateArgs,
 
 		WorkaroundOutputDirIssue: u.WorkaroundOutputDirIssue,
 	}

--- a/replace.go
+++ b/replace.go
@@ -55,6 +55,9 @@ type ReplaceWithRenderedOpts struct {
 	// templating in contrast to --validate
 	ApiVersions []string
 
+	// TemplateArgs to pass Flags to helm template
+	TemplateArgs string
+
 	// WorkaroundOutputDirIssue prevents chartify from using `helm template --output-dir` and let it use `helm template > some.yaml` instead to
 	// workaround the potential helm issue
 	// See https://github.com/roboll/helmfile/issues/1279#issuecomment-636839395
@@ -83,6 +86,10 @@ func (r *Runner) ReplaceWithRendered(name, chartName, chartPath string, o Replac
 		additionalFlags += createFlagChain("kube-version", []string{o.KubeVersion})
 	}
 	additionalFlags += createFlagChain("api-versions", o.ApiVersions)
+
+	if o.TemplateArgs != "" {
+		additionalFlags += fmt.Sprintf(" %s", o.TemplateArgs)
+	}
 
 	r.Logf("options: %v", o)
 

--- a/tempdir_test.go
+++ b/tempdir_test.go
@@ -35,21 +35,21 @@ func TestGenerateID(t *testing.T) {
 		release: "foo",
 		chart:   "incubator/raw",
 		opts:    ChartifyOpts{},
-		want:    "foo-6f46b78b5b",
+		want:    "foo-5b569f58ff",
 	})
 
 	run(testcase{
 		release: "foo",
 		chart:   "stable/envoy",
 		opts:    ChartifyOpts{},
-		want:    "foo-6d8599cd4f",
+		want:    "foo-7b5895898b",
 	})
 
 	run(testcase{
 		release: "bar",
 		chart:   "incubator/raw",
 		opts:    ChartifyOpts{},
-		want:    "bar-fdcc5d457",
+		want:    "bar-6c86897994",
 	})
 
 	run(testcase{
@@ -57,7 +57,7 @@ func TestGenerateID(t *testing.T) {
 		opts: ChartifyOpts{
 			Namespace: "myns",
 		},
-		want: "myns-foo-7fbbf674bf",
+		want: "myns-foo-564b5d8874",
 	})
 
 	for id, n := range ids {


### PR DESCRIPTION
Adding `TemplateArgs` to allow passing any args to the helm template function.
I use this to pass `--dry-run=server` for helmfile apply (which is using helm template underneath) . This enables me to use the `lookup` functionality in my helm charts.
helmfile PR is already prepared and will follow.