### PR TITLE
build: update Helm version to v3.16.4

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         mkdir ./bin
 
-        HELM_VERSION=v3.16.3
+        HELM_VERSION=v3.16.4
         HELM_LOCATION="https://get.helm.sh"
         HELM_FILENAME="helm-${HELM_VERSION}-linux-amd64.tar.gz"
         curl -LO ${HELM_LOCATION}/${HELM_FILENAME} && \


### PR DESCRIPTION
This pull request includes an update to the `jobs:` section in the `.github/workflows/go.yml` file to use a newer version of Helm.

* Updated Helm version from `v3.16.3` to `v3.16.4` in `.github/workflows/go.yml`.