### PR TITLE
build: update Helm version to v3.17.1

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         mkdir ./bin
 
-        HELM_VERSION=v3.17.0
+        HELM_VERSION=v3.17.1
         HELM_LOCATION="https://get.helm.sh"
         HELM_FILENAME="helm-${HELM_VERSION}-linux-amd64.tar.gz"
         curl -LO ${HELM_LOCATION}/${HELM_FILENAME} && \


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/go.yml` file. The change updates the Helm version from `v3.17.0` to `v3.17.1`.