### PR TITLE
build: update golang version to 1.24 and golangci-lint to v1.64.5

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -24,4 +24,4 @@ jobs:
       - name: Golangci lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.61.0
+          version: v1.64.5

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/helmfile/chartify
 
-go 1.23.0
+go 1.24
 
 require (
 	github.com/Masterminds/semver/v3 v3.3.1


### PR DESCRIPTION
This pull request includes updates to the Go version and the Golangci-lint version used in the project. The most important changes are:

* [`.github/workflows/lint.yaml`](diffhunk://#diff-4b122024a3a28ded65da76a2f1bface1f3a27328374438d1298d25585fe0603bL27-R27): Updated the Golangci-lint version from `v1.61.0` to `v1.64.5`.
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3): Updated the Go version from `1.23.0` to `1.24`.