### PR TITLE
build: update Helm version to v3.17.2

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         mkdir ./bin
 
-        HELM_VERSION=v3.17.1
+        HELM_VERSION=v3.17.2
         HELM_LOCATION="https://get.helm.sh"
         HELM_FILENAME="helm-${HELM_VERSION}-linux-amd64.tar.gz"
         curl -LO ${HELM_LOCATION}/${HELM_FILENAME} && \


### PR DESCRIPTION
This pull request includes a minor version update for the Helm tool in the GitHub Actions workflow configuration file. The change updates the Helm version from v3.17.1 to v3.17.2 to ensure the workflow uses the latest version.

* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL25-R25): Updated Helm version from v3.17.1 to v3.17.2.