### PR TITLE
build: update Helm to version v3.17.3

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install Helm
       uses: azure/setup-helm@v4.3.0
       with:
-        version: v3.17.2 # default is latest (stable)
+        version: v3.17.3 # default is latest (stable)
 
     - name: Install Kustomize
       uses: syntaqx/setup-kustomize@v1


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/go.yml` file. The change updates the Helm version used in the workflow from `v3.17.2` to `v3.17.3`.