### PR TITLE
build: update Helm to version v3.18.0

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install Helm
       uses: azure/setup-helm@v4.3.0
       with:
-        version: v3.17.3 # default is latest (stable)
+        version: v3.18.0 # default is latest (stable)
 
     - name: Install Kustomize
       uses: syntaqx/setup-kustomize@v1


### PR DESCRIPTION
This pull request updates the Helm version used in the GitHub Actions workflow for Go projects.

* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL24-R24): Updated the Helm version from `v3.17.3` to `v3.18.0` in the workflow configuration.