### PR TITLE
fix(testdata): update kube and api versions in test case

### DIFF
--- a/testdata/integration/testcases/kube_version_and_api_versions/want
+++ b/testdata/integration/testcases/kube_version_and_api_versions/want
@@ -51,17 +51,18 @@ data:
   apiVersion42: rbac.authorization.k8s.io/v1
   apiVersion43: rbac.authorization.k8s.io/v1beta1
   apiVersion44: rbac.authorization.k8s.io/v1alpha1
-  apiVersion45: resource.k8s.io/v1beta1
-  apiVersion46: resource.k8s.io/v1alpha3
-  apiVersion47: scheduling.k8s.io/v1alpha1
-  apiVersion48: scheduling.k8s.io/v1beta1
-  apiVersion49: scheduling.k8s.io/v1
-  apiVersion50: storage.k8s.io/v1beta1
-  apiVersion51: storage.k8s.io/v1
-  apiVersion52: storage.k8s.io/v1alpha1
-  apiVersion53: storagemigration.k8s.io/v1alpha1
-  apiVersion54: apiextensions.k8s.io/v1beta1
-  apiVersion55: apiextensions.k8s.io/v1
-  apiVersion56: foo/v1alpha1
-  apiVersion57: bar/v1beta1
-  apiVersion58: baz/v1
+  apiVersion45: resource.k8s.io/v1beta2
+  apiVersion46: resource.k8s.io/v1beta1
+  apiVersion47: resource.k8s.io/v1alpha3
+  apiVersion48: scheduling.k8s.io/v1alpha1
+  apiVersion49: scheduling.k8s.io/v1beta1
+  apiVersion50: scheduling.k8s.io/v1
+  apiVersion51: storage.k8s.io/v1beta1
+  apiVersion52: storage.k8s.io/v1
+  apiVersion53: storage.k8s.io/v1alpha1
+  apiVersion54: storagemigration.k8s.io/v1alpha1
+  apiVersion55: apiextensions.k8s.io/v1beta1
+  apiVersion56: apiextensions.k8s.io/v1
+  apiVersion57: foo/v1alpha1
+  apiVersion58: bar/v1beta1
+  apiVersion59: baz/v1


### PR DESCRIPTION
This pull request updates the `want` test data for Kubernetes API versions in the `testdata/integration/testcases/kube_version_and_api_versions` directory. The changes involve replacing and reordering several API versions to align with updated specifications.

Updates to Kubernetes API versions:

* Replaced `resource.k8s.io/v1beta1` with `resource.k8s.io/v1beta2` and reintroduced `resource.k8s.io/v1beta1` in the correct order.
* Reordered and reintroduced several API versions (`scheduling.k8s.io`, `storage.k8s.io`, `storagemigration.k8s.io`, `apiextensions.k8s.io`, and custom APIs like `foo`, `bar`, and `baz`) to ensure proper alignment with the updated test data structure.