### PR TITLE
build: update Helm and Helm dependency to v3.18.3

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install Helm
       uses: azure/setup-helm@v4.3.0
       with:
-        version: v3.18.2 # default is latest (stable)
+        version: v3.18.3 # default is latest (stable)
 
     - name: Install Kustomize
       uses: syntaqx/setup-kustomize@v1


### PR DESCRIPTION
This pull request includes a minor update to the `.github/workflows/go.yml` file. The change updates the Helm installation version from `v3.18.2` to `v3.18.3` to ensure the workflow uses the latest stable version.