### PR TITLE
fix: validate and preprocess version in FindSemVerInfo

### DIFF
--- a/util.go
+++ b/util.go
@@ -51,7 +51,14 @@ func indent(text, indent string) string {
 }
 
 func FindSemVerInfo(version string) (string, error) {
-	v := regexp.MustCompile(semVerRegex).FindString(version)
+	if version == "" {
+		return "", fmt.Errorf("version cannot be empty")
+	}
+	processedVersion := strings.TrimSpace(version)
+	if !strings.HasPrefix(processedVersion, "v") {
+		processedVersion = fmt.Sprintf("v%s", processedVersion)
+	}
+	v := regexp.MustCompile(semVerRegex).FindString(processedVersion)
 
 	if v == "" {
 		return "", fmt.Errorf("unable to find semver info in %s", version)

--- a/util_test.go
+++ b/util_test.go
@@ -82,10 +82,10 @@ func TestFindSemVerInfo(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:    "semver must start with v",
+			name:    "semver not start with v",
 			version: "1.2.3",
-			want:    "",
-			wantErr: true,
+			want:    "v1.2.3",
+			wantErr: false,
 		},
 		{
 			name:    "helm version info with WARNING message",


### PR DESCRIPTION
This pull request improves the robustness and usability of the `FindSemVerInfo` utility function by handling empty and non-prefixed version strings, and updates the related tests to reflect the new behavior.

Enhancements to version string handling:

* Updated `FindSemVerInfo` in `util.go` to return an error if the input version string is empty and to automatically add a `v` prefix if it's missing before extracting the semantic version.

Test updates:

* Modified the test case in `util_test.go` to expect a valid semver result when the version string does not start with `v`, reflecting the new logic in `FindSemVerInfo`.