### PR TITLE
feat: Allow using kubectl built-in kustomize when separate kustomize binary is missing

### DIFF
--- a/kubectl_kustomize_test.go
+++ b/kubectl_kustomize_test.go
@@ -1,0 +1,57 @@
+package chartify
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestKubectlKustomizeFallback(t *testing.T) {
+	if _, err := exec.LookPath("kubectl"); err != nil {
+		t.Skip("kubectl binary not found in PATH")
+	}
+
+	t.Run("KustomizeBuild with kubectl kustomize", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		srcDir := t.TempDir()
+
+		kustomizationContent := `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deployment.yaml
+`
+		deploymentContent := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test
+  template:
+    metadata:
+      labels:
+        app: test
+    spec:
+      containers:
+      - name: test
+        image: test:latest
+`
+
+		templatesDir := filepath.Join(tmpDir, "templates")
+		require.NoError(t, os.MkdirAll(templatesDir, 0755))
+
+		require.NoError(t, os.WriteFile(filepath.Join(srcDir, "kustomization.yaml"), []byte(kustomizationContent), 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(srcDir, "deployment.yaml"), []byte(deploymentContent), 0644))
+
+		r := New(KustomizeBin("kubectl kustomize"))
+
+		outputFile, err := r.KustomizeBuild(srcDir, tmpDir)
+		require.NoError(t, err)
+		require.FileExists(t, outputFile)
+	})
+}

--- a/kubectl_kustomize_test.go
+++ b/kubectl_kustomize_test.go
@@ -2,7 +2,6 @@ package chartify
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -14,9 +13,32 @@ import (
 // in TestKustomizeBin.
 func TestKubectlKustomize(t *testing.T) {
 	t.Run("KustomizeBuild succeeds with kubectl kustomize option", func(t *testing.T) {
-		if _, err := exec.LookPath("kubectl"); err != nil {
-			t.Skip("kubectl binary not found in PATH")
-		}
+		// Create a stub kubectl that handles the kustomize subcommand,
+		// so this test is self-contained and not skipped when kubectl is absent.
+		stubDir := t.TempDir()
+		stubKubectl := filepath.Join(stubDir, "kubectl")
+		// The stub writes minimal valid YAML to the -o output file.
+		stubScript := []byte(`#!/bin/sh
+# Stub kubectl for testing kubectl kustomize
+if [ "$1" = "kustomize" ]; then
+  shift
+  OUTPUT=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      -o) OUTPUT="$2"; shift 2;;
+      *) shift;;
+    esac
+  done
+  if [ -n "$OUTPUT" ]; then
+    printf 'apiVersion: v1\nkind: List\nitems: []\n' > "$OUTPUT"
+  fi
+fi
+`)
+		require.NoError(t, os.WriteFile(stubKubectl, stubScript, 0755))
+
+		origPath := os.Getenv("PATH")
+		defer os.Setenv("PATH", origPath)
+		os.Setenv("PATH", stubDir+":"+origPath)
 
 		tmpDir := t.TempDir()
 		srcDir := t.TempDir()

--- a/kubectl_kustomize_test.go
+++ b/kubectl_kustomize_test.go
@@ -28,12 +28,11 @@ if [ "$1" = "kustomize" ]; then
 fi
 `
 
-// writeStubKubectl creates a stub kubectl script in dir and returns its path.
-func writeStubKubectl(t *testing.T, dir string) string {
+// writeStubKubectl creates a stub kubectl script in dir.
+func writeStubKubectl(t *testing.T, dir string) {
 	t.Helper()
 	p := filepath.Join(dir, "kubectl")
 	require.NoError(t, os.WriteFile(p, []byte(stubKubectlScript), 0755))
-	return p
 }
 
 // TestKubectlKustomize tests behavior when kubectl kustomize is explicitly configured

--- a/kubectl_kustomize_test.go
+++ b/kubectl_kustomize_test.go
@@ -10,11 +10,11 @@ import (
 )
 
 func TestKubectlKustomizeFallback(t *testing.T) {
-	if _, err := exec.LookPath("kubectl"); err != nil {
-		t.Skip("kubectl binary not found in PATH")
-	}
-
 	t.Run("KustomizeBuild with kubectl kustomize", func(t *testing.T) {
+		if _, err := exec.LookPath("kubectl"); err != nil {
+			t.Skip("kubectl binary not found in PATH")
+		}
+
 		tmpDir := t.TempDir()
 		srcDir := t.TempDir()
 
@@ -53,5 +53,54 @@ spec:
 		outputFile, err := r.KustomizeBuild(srcDir, tmpDir)
 		require.NoError(t, err)
 		require.FileExists(t, outputFile)
+	})
+
+	t.Run("edit commands not supported with kubectl kustomize", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		srcDir := t.TempDir()
+
+		kustomizationContent := `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deployment.yaml
+`
+		deploymentContent := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test
+  template:
+    metadata:
+      labels:
+        app: test
+    spec:
+      containers:
+      - name: test
+        image: test:latest
+`
+
+		templatesDir := filepath.Join(tmpDir, "templates")
+		valuesDir := t.TempDir()
+		valuesFile := filepath.Join(valuesDir, "values.yaml")
+		valuesContent := `images:
+- name: test
+  newName: newtest
+  newTag: v2
+`
+
+		require.NoError(t, os.MkdirAll(templatesDir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(srcDir, "kustomization.yaml"), []byte(kustomizationContent), 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(srcDir, "deployment.yaml"), []byte(deploymentContent), 0644))
+		require.NoError(t, os.WriteFile(valuesFile, []byte(valuesContent), 0644))
+
+		r := New(KustomizeBin("kubectl kustomize"))
+
+		_, err := r.KustomizeBuild(srcDir, tmpDir, &KustomizeBuildOpts{ValuesFiles: []string{valuesFile}})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "setting images via kustomizeOpts.Images is not supported when using 'kubectl kustomize'")
 	})
 }

--- a/kubectl_kustomize_test.go
+++ b/kubectl_kustomize_test.go
@@ -8,37 +8,46 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestKubectlKustomize tests behavior when kubectl kustomize is explicitly configured
-// via KustomizeBin("kubectl kustomize"). The automatic fallback selection is tested
-// in TestKustomizeBin.
-func TestKubectlKustomize(t *testing.T) {
-	t.Run("KustomizeBuild succeeds with kubectl kustomize option", func(t *testing.T) {
-		// Create a stub kubectl that handles the kustomize subcommand,
-		// so this test is self-contained and not skipped when kubectl is absent.
-		stubDir := t.TempDir()
-		stubKubectl := filepath.Join(stubDir, "kubectl")
-		// The stub writes minimal valid YAML to the -o output file.
-		stubScript := []byte(`#!/bin/sh
-# Stub kubectl for testing kubectl kustomize
+// stubKubectlScript is a minimal sh script that acts as a kubectl stub for tests.
+// It handles `kubectl kustomize <dir> [-o|-o FILE|--output FILE]` by writing
+// a minimal valid Kubernetes Deployment YAML to the specified output file.
+const stubKubectlScript = `#!/bin/sh
 if [ "$1" = "kustomize" ]; then
   shift
   OUTPUT=""
   while [ $# -gt 0 ]; do
     case "$1" in
       -o) OUTPUT="$2"; shift 2;;
+      --output) OUTPUT="$2"; shift 2;;
       *) shift;;
     esac
   done
   if [ -n "$OUTPUT" ]; then
-    printf 'apiVersion: v1\nkind: List\nitems: []\n' > "$OUTPUT"
+    printf 'apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: stub\n' > "$OUTPUT"
   fi
 fi
-`)
-		require.NoError(t, os.WriteFile(stubKubectl, stubScript, 0755))
+`
+
+// writeStubKubectl creates a stub kubectl script in dir and returns its path.
+func writeStubKubectl(t *testing.T, dir string) string {
+	t.Helper()
+	p := filepath.Join(dir, "kubectl")
+	require.NoError(t, os.WriteFile(p, []byte(stubKubectlScript), 0755))
+	return p
+}
+
+// TestKubectlKustomize tests behavior when kubectl kustomize is explicitly configured
+// via KustomizeBin("kubectl kustomize"). The automatic fallback selection is tested
+// in TestKustomizeBin.
+func TestKubectlKustomize(t *testing.T) {
+	t.Run("KustomizeBuild succeeds with kubectl kustomize option", func(t *testing.T) {
+		// Create a stub kubectl so the test is self-contained and always runs in CI.
+		stubDir := t.TempDir()
+		writeStubKubectl(t, stubDir)
 
 		origPath := os.Getenv("PATH")
 		defer os.Setenv("PATH", origPath)
-		os.Setenv("PATH", stubDir+":"+origPath)
+		os.Setenv("PATH", stubDir+string(os.PathListSeparator)+origPath)
 
 		tmpDir := t.TempDir()
 		srcDir := t.TempDir()
@@ -78,6 +87,31 @@ spec:
 		outputFile, err := r.KustomizeBuild(srcDir, tmpDir)
 		require.NoError(t, err)
 		require.FileExists(t, outputFile)
+	})
+
+	t.Run("Patch succeeds with kubectl kustomize option", func(t *testing.T) {
+		// Create a stub kubectl so the test is self-contained and always runs in CI.
+		stubDir := t.TempDir()
+		writeStubKubectl(t, stubDir)
+
+		origPath := os.Getenv("PATH")
+		defer os.Setenv("PATH", origPath)
+		os.Setenv("PATH", stubDir+string(os.PathListSeparator)+origPath)
+
+		tempDir := t.TempDir()
+
+		// Write a minimal manifest file that Patch() will reference.
+		manifestPath := filepath.Join(tempDir, "templates", "deploy.yaml")
+		require.NoError(t, os.MkdirAll(filepath.Dir(manifestPath), 0755))
+		require.NoError(t, os.WriteFile(manifestPath, []byte(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+`), 0644))
+
+		r := New(KustomizeBin("kubectl kustomize"))
+		err := r.Patch(tempDir, []string{manifestPath}, &PatchOpts{})
+		require.NoError(t, err)
 	})
 
 	t.Run("edit commands not supported with kubectl kustomize", func(t *testing.T) {
@@ -126,6 +160,6 @@ spec:
 
 		_, err := r.KustomizeBuild(srcDir, tmpDir, &KustomizeBuildOpts{ValuesFiles: []string{valuesFile}})
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "setting images via kustomizeOpts.Images is not supported when using 'kubectl kustomize'")
+		require.Contains(t, err.Error(), "setting images via Chartify values files or kustomize build options is not supported when using 'kubectl kustomize'")
 	})
 }

--- a/kubectl_kustomize_test.go
+++ b/kubectl_kustomize_test.go
@@ -9,8 +9,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestKubectlKustomizeFallback(t *testing.T) {
-	t.Run("KustomizeBuild with kubectl kustomize", func(t *testing.T) {
+// TestKubectlKustomize tests behavior when kubectl kustomize is explicitly configured
+// via KustomizeBin("kubectl kustomize"). The automatic fallback selection is tested
+// in TestKustomizeBin.
+func TestKubectlKustomize(t *testing.T) {
+	t.Run("KustomizeBuild succeeds with kubectl kustomize option", func(t *testing.T) {
 		if _, err := exec.LookPath("kubectl"); err != nil {
 			t.Skip("kubectl binary not found in PATH")
 		}

--- a/kubectl_kustomize_test.go
+++ b/kubectl_kustomize_test.go
@@ -114,51 +114,56 @@ metadata:
 	})
 
 	t.Run("edit commands not supported with kubectl kustomize", func(t *testing.T) {
-		tmpDir := t.TempDir()
 		srcDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(srcDir, "kustomization.yaml"), []byte("apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\n"), 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(srcDir, "deployment.yaml"), []byte("apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: test\n"), 0644))
 
-		kustomizationContent := `apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-- deployment.yaml
-`
-		deploymentContent := `apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: test
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: test
-  template:
-    metadata:
-      labels:
-        app: test
-    spec:
-      containers:
-      - name: test
-        image: test:latest
-`
+		cases := []struct {
+			name          string
+			valuesContent string
+			wantErrSubstr string
+		}{
+			{
+				name:          "images",
+				valuesContent: "images:\n- name: test\n  newName: newtest\n  newTag: v2\n",
+				wantErrSubstr: "setting images via Chartify values files or kustomize build options is not supported when using 'kubectl kustomize'",
+			},
+			{
+				name:          "namePrefix",
+				valuesContent: "namePrefix: prod-\n",
+				wantErrSubstr: "setting namePrefix via Chartify values files or kustomize build options is not supported when using 'kubectl kustomize'",
+			},
+			{
+				name:          "nameSuffix",
+				valuesContent: "nameSuffix: -v2\n",
+				wantErrSubstr: "setting nameSuffix via Chartify values files or kustomize build options is not supported when using 'kubectl kustomize'",
+			},
+			{
+				name:          "namespace",
+				valuesContent: "namespace: prod\n",
+				wantErrSubstr: "setting namespace via Chartify values files or kustomize build options is not supported when using 'kubectl kustomize'",
+			},
+		}
 
-		templatesDir := filepath.Join(tmpDir, "templates")
-		valuesDir := t.TempDir()
-		valuesFile := filepath.Join(valuesDir, "values.yaml")
-		valuesContent := `images:
-- name: test
-  newName: newtest
-  newTag: v2
-`
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				tmpDir := t.TempDir()
+				valuesDir := t.TempDir()
+				valuesFile := filepath.Join(valuesDir, "values.yaml")
 
-		require.NoError(t, os.MkdirAll(templatesDir, 0755))
-		require.NoError(t, os.WriteFile(filepath.Join(srcDir, "kustomization.yaml"), []byte(kustomizationContent), 0644))
-		require.NoError(t, os.WriteFile(filepath.Join(srcDir, "deployment.yaml"), []byte(deploymentContent), 0644))
-		require.NoError(t, os.WriteFile(valuesFile, []byte(valuesContent), 0644))
+				require.NoError(t, os.WriteFile(valuesFile, []byte(tc.valuesContent), 0644))
 
-		r := New(KustomizeBin("kubectl kustomize"))
+				r := New(KustomizeBin("kubectl kustomize"))
 
-		_, err := r.KustomizeBuild(srcDir, tmpDir, &KustomizeBuildOpts{ValuesFiles: []string{valuesFile}})
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "setting images via Chartify values files or kustomize build options is not supported when using 'kubectl kustomize'")
+				_, err := r.KustomizeBuild(srcDir, tmpDir, &KustomizeBuildOpts{ValuesFiles: []string{valuesFile}})
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.wantErrSubstr)
+
+				// Validation happens before file I/O, so tempDir must be left clean.
+				entries, err := os.ReadDir(tmpDir)
+				require.NoError(t, err)
+				require.Empty(t, entries, "tempDir should be empty when validation fails before I/O")
+			})
+		}
 	})
 }

--- a/kustomize.go
+++ b/kustomize.go
@@ -264,11 +264,6 @@ func (r *Runner) kustomizeVersion() (*semver.Version, error) {
 	return version, nil
 }
 
-// isUsingKubectlKustomize checks if we're using kubectl's built-in kustomize
-func (r *Runner) isUsingKubectlKustomize() bool {
-	return r.kustomizeBin() == "kubectl kustomize"
-}
-
 // kustomizeEnableAlphaPluginsFlag returns the kustomize binary alpha plugin argument.
 // Above Kustomize v3, it is `--enable-alpha-plugins`.
 // Below Kustomize v3 (including v3), it is `--enable_alpha_plugins`.

--- a/kustomize.go
+++ b/kustomize.go
@@ -123,6 +123,10 @@ func (r *Runner) KustomizeBuild(srcDir string, tempDir string, opts ...Kustomize
 		panic("--set is not yet supported for kustomize-based apps! Use -f/--values flag instead.")
 	}
 
+	// Resolve the kustomize binary once so PATH lookups are not repeated for every check.
+	bin := r.kustomizeBin()
+	usingKubectl := bin == "kubectl kustomize"
+
 	prevDir, err := os.Getwd()
 	if err != nil {
 		return "", err
@@ -149,43 +153,43 @@ func (r *Runner) KustomizeBuild(srcDir string, tempDir string, opts ...Kustomize
 	}
 
 	if len(kustomizeOpts.Images) > 0 {
-		if r.isUsingKubectlKustomize() {
-			return "", fmt.Errorf("setting images via kustomizeOpts.Images is not supported when using 'kubectl kustomize'. Please set images directly in your kustomization.yaml file")
+		if usingKubectl {
+			return "", fmt.Errorf("setting images via Chartify values files or kustomize build options is not supported when using 'kubectl kustomize'. Please set images directly in your kustomization.yaml file")
 		}
 		args := []string{"edit", "set", "image"}
 		for _, image := range kustomizeOpts.Images {
 			args = append(args, image.String())
 		}
-		_, err := r.runInDir(tempDir, r.kustomizeBin(), args...)
+		_, err := r.runInDir(tempDir, bin, args...)
 		if err != nil {
 			return "", err
 		}
 	}
 	if kustomizeOpts.NamePrefix != "" {
-		if r.isUsingKubectlKustomize() {
-			return "", fmt.Errorf("setting namePrefix via kustomizeOpts.NamePrefix is not supported when using 'kubectl kustomize'. Please set namePrefix directly in your kustomization.yaml file")
+		if usingKubectl {
+			return "", fmt.Errorf("setting namePrefix via Chartify values files or kustomize build options is not supported when using 'kubectl kustomize'. Please set namePrefix directly in your kustomization.yaml file")
 		}
-		_, err := r.runInDir(tempDir, r.kustomizeBin(), "edit", "set", "nameprefix", kustomizeOpts.NamePrefix)
+		_, err := r.runInDir(tempDir, bin, "edit", "set", "nameprefix", kustomizeOpts.NamePrefix)
 		if err != nil {
 			fmt.Println(err)
 			return "", err
 		}
 	}
 	if kustomizeOpts.NameSuffix != "" {
-		if r.isUsingKubectlKustomize() {
-			return "", fmt.Errorf("setting nameSuffix via kustomizeOpts.NameSuffix is not supported when using 'kubectl kustomize'. Please set nameSuffix directly in your kustomization.yaml file")
+		if usingKubectl {
+			return "", fmt.Errorf("setting nameSuffix via Chartify values files or kustomize build options is not supported when using 'kubectl kustomize'. Please set nameSuffix directly in your kustomization.yaml file")
 		}
 		// "--" is there to avoid `namesuffix -acme` to fail due to `-a` being considered as a flag
-		_, err := r.runInDir(tempDir, r.kustomizeBin(), "edit", "set", "namesuffix", "--", kustomizeOpts.NameSuffix)
+		_, err := r.runInDir(tempDir, bin, "edit", "set", "namesuffix", "--", kustomizeOpts.NameSuffix)
 		if err != nil {
 			return "", err
 		}
 	}
 	if kustomizeOpts.Namespace != "" {
-		if r.isUsingKubectlKustomize() {
-			return "", fmt.Errorf("setting namespace via kustomizeOpts.Namespace is not supported when using 'kubectl kustomize'. Please set namespace directly in your kustomization.yaml file")
+		if usingKubectl {
+			return "", fmt.Errorf("setting namespace via Chartify values files or kustomize build options is not supported when using 'kubectl kustomize'. Please set namespace directly in your kustomization.yaml file")
 		}
-		_, err := r.runInDir(tempDir, r.kustomizeBin(), "edit", "set", "namespace", kustomizeOpts.Namespace)
+		_, err := r.runInDir(tempDir, bin, "edit", "set", "namespace", kustomizeOpts.Namespace)
 		if err != nil {
 			return "", err
 		}
@@ -208,18 +212,18 @@ func (r *Runner) KustomizeBuild(srcDir string, tempDir string, opts ...Kustomize
 	outputFile := filepath.Join(tempDir, "templates", "kustomized.yaml")
 	kustomizeArgs := []string{"-o", outputFile}
 
-	if !r.isUsingKubectlKustomize() {
+	if !usingKubectl {
 		kustomizeArgs = append(kustomizeArgs, "build")
 	}
 
 	if u.EnableAlphaPlugins {
-		f, err := r.kustomizeEnableAlphaPluginsFlag()
+		f, err := r.kustomizeEnableAlphaPluginsFlag(usingKubectl)
 		if err != nil {
 			return "", err
 		}
 		kustomizeArgs = append(kustomizeArgs, f)
 	}
-	f, err := r.kustomizeLoadRestrictionsNoneFlag()
+	f, err := r.kustomizeLoadRestrictionsNoneFlag(usingKubectl)
 	if err != nil {
 		return "", err
 	}
@@ -229,7 +233,7 @@ func (r *Runner) KustomizeBuild(srcDir string, tempDir string, opts ...Kustomize
 		kustomizeArgs = append(kustomizeArgs, "--helm-command="+u.HelmBinary)
 	}
 
-	out, err := r.runInDir(tempDir, r.kustomizeBin(), append(kustomizeArgs, tempDir)...)
+	out, err := r.runInDir(tempDir, bin, append(kustomizeArgs, tempDir)...)
 	if err != nil {
 		return "", err
 	}
@@ -268,8 +272,8 @@ func (r *Runner) isUsingKubectlKustomize() bool {
 // kustomizeEnableAlphaPluginsFlag returns the kustomize binary alpha plugin argument.
 // Above Kustomize v3, it is `--enable-alpha-plugins`.
 // Below Kustomize v3 (including v3), it is `--enable_alpha_plugins`.
-func (r *Runner) kustomizeEnableAlphaPluginsFlag() (string, error) {
-	if r.isUsingKubectlKustomize() {
+func (r *Runner) kustomizeEnableAlphaPluginsFlag(usingKubectl bool) (string, error) {
+	if usingKubectl {
 		return "--enable-alpha-plugins", nil
 	}
 	version, err := r.kustomizeVersion()
@@ -286,8 +290,8 @@ func (r *Runner) kustomizeEnableAlphaPluginsFlag() (string, error) {
 // the root argument.
 // Above Kustomize v3, it is `--load-restrictor=LoadRestrictionsNone`.
 // Below Kustomize v3 (including v3), it is `--load_restrictor=none`.
-func (r *Runner) kustomizeLoadRestrictionsNoneFlag() (string, error) {
-	if r.isUsingKubectlKustomize() {
+func (r *Runner) kustomizeLoadRestrictionsNoneFlag(usingKubectl bool) (string, error) {
+	if usingKubectl {
 		return "--load-restrictor=LoadRestrictionsNone", nil
 	}
 	version, err := r.kustomizeVersion()

--- a/kustomize.go
+++ b/kustomize.go
@@ -149,6 +149,9 @@ func (r *Runner) KustomizeBuild(srcDir string, tempDir string, opts ...Kustomize
 	}
 
 	if len(kustomizeOpts.Images) > 0 {
+		if r.isUsingKubectlKustomize() {
+			return "", fmt.Errorf("setting images via kustomizeOpts.Images is not supported when using 'kubectl kustomize'. Please set images directly in your kustomization.yaml file")
+		}
 		args := []string{"edit", "set", "image"}
 		for _, image := range kustomizeOpts.Images {
 			args = append(args, image.String())
@@ -159,6 +162,9 @@ func (r *Runner) KustomizeBuild(srcDir string, tempDir string, opts ...Kustomize
 		}
 	}
 	if kustomizeOpts.NamePrefix != "" {
+		if r.isUsingKubectlKustomize() {
+			return "", fmt.Errorf("setting namePrefix via kustomizeOpts.NamePrefix is not supported when using 'kubectl kustomize'. Please set namePrefix directly in your kustomization.yaml file")
+		}
 		_, err := r.runInDir(tempDir, r.kustomizeBin(), "edit", "set", "nameprefix", kustomizeOpts.NamePrefix)
 		if err != nil {
 			fmt.Println(err)
@@ -166,6 +172,9 @@ func (r *Runner) KustomizeBuild(srcDir string, tempDir string, opts ...Kustomize
 		}
 	}
 	if kustomizeOpts.NameSuffix != "" {
+		if r.isUsingKubectlKustomize() {
+			return "", fmt.Errorf("setting nameSuffix via kustomizeOpts.NameSuffix is not supported when using 'kubectl kustomize'. Please set nameSuffix directly in your kustomization.yaml file")
+		}
 		// "--" is there to avoid `namesuffix -acme` to fail due to `-a` being considered as a flag
 		_, err := r.runInDir(tempDir, r.kustomizeBin(), "edit", "set", "namesuffix", "--", kustomizeOpts.NameSuffix)
 		if err != nil {
@@ -173,6 +182,9 @@ func (r *Runner) KustomizeBuild(srcDir string, tempDir string, opts ...Kustomize
 		}
 	}
 	if kustomizeOpts.Namespace != "" {
+		if r.isUsingKubectlKustomize() {
+			return "", fmt.Errorf("setting namespace via kustomizeOpts.Namespace is not supported when using 'kubectl kustomize'. Please set namespace directly in your kustomization.yaml file")
+		}
 		_, err := r.runInDir(tempDir, r.kustomizeBin(), "edit", "set", "namespace", kustomizeOpts.Namespace)
 		if err != nil {
 			return "", err
@@ -194,7 +206,11 @@ func (r *Runner) KustomizeBuild(srcDir string, tempDir string, opts ...Kustomize
 		}
 	}
 	outputFile := filepath.Join(tempDir, "templates", "kustomized.yaml")
-	kustomizeArgs := []string{"-o", outputFile, "build"}
+	kustomizeArgs := []string{"-o", outputFile}
+
+	if !r.isUsingKubectlKustomize() {
+		kustomizeArgs = append(kustomizeArgs, "build")
+	}
 
 	if u.EnableAlphaPlugins {
 		f, err := r.kustomizeEnableAlphaPluginsFlag()
@@ -244,10 +260,18 @@ func (r *Runner) kustomizeVersion() (*semver.Version, error) {
 	return version, nil
 }
 
+// isUsingKubectlKustomize checks if we're using kubectl's built-in kustomize
+func (r *Runner) isUsingKubectlKustomize() bool {
+	return r.kustomizeBin() == "kubectl kustomize"
+}
+
 // kustomizeEnableAlphaPluginsFlag returns the kustomize binary alpha plugin argument.
 // Above Kustomize v3, it is `--enable-alpha-plugins`.
 // Below Kustomize v3 (including v3), it is `--enable_alpha_plugins`.
 func (r *Runner) kustomizeEnableAlphaPluginsFlag() (string, error) {
+	if r.isUsingKubectlKustomize() {
+		return "--enable-alpha-plugins", nil
+	}
 	version, err := r.kustomizeVersion()
 	if err != nil {
 		return "", err
@@ -263,6 +287,9 @@ func (r *Runner) kustomizeEnableAlphaPluginsFlag() (string, error) {
 // Above Kustomize v3, it is `--load-restrictor=LoadRestrictionsNone`.
 // Below Kustomize v3 (including v3), it is `--load_restrictor=none`.
 func (r *Runner) kustomizeLoadRestrictionsNoneFlag() (string, error) {
+	if r.isUsingKubectlKustomize() {
+		return "--load-restrictor=LoadRestrictionsNone", nil
+	}
 	version, err := r.kustomizeVersion()
 	if err != nil {
 		return "", err

--- a/kustomize.go
+++ b/kustomize.go
@@ -127,6 +127,23 @@ func (r *Runner) KustomizeBuild(srcDir string, tempDir string, opts ...Kustomize
 	bin := r.kustomizeBin()
 	usingKubectl := bin == "kubectl kustomize"
 
+	// kubectl kustomize has no "edit" subcommand, so validate up front (before any file I/O)
+	// to avoid leaving stale files in tempDir on error.
+	if usingKubectl {
+		if len(kustomizeOpts.Images) > 0 {
+			return "", fmt.Errorf("setting images via Chartify values files or kustomize build options is not supported when using 'kubectl kustomize'. Please set images directly in your kustomization.yaml file")
+		}
+		if kustomizeOpts.NamePrefix != "" {
+			return "", fmt.Errorf("setting namePrefix via Chartify values files or kustomize build options is not supported when using 'kubectl kustomize'. Please set namePrefix directly in your kustomization.yaml file")
+		}
+		if kustomizeOpts.NameSuffix != "" {
+			return "", fmt.Errorf("setting nameSuffix via Chartify values files or kustomize build options is not supported when using 'kubectl kustomize'. Please set nameSuffix directly in your kustomization.yaml file")
+		}
+		if kustomizeOpts.Namespace != "" {
+			return "", fmt.Errorf("setting namespace via Chartify values files or kustomize build options is not supported when using 'kubectl kustomize'. Please set namespace directly in your kustomization.yaml file")
+		}
+	}
+
 	prevDir, err := os.Getwd()
 	if err != nil {
 		return "", err
@@ -153,9 +170,6 @@ func (r *Runner) KustomizeBuild(srcDir string, tempDir string, opts ...Kustomize
 	}
 
 	if len(kustomizeOpts.Images) > 0 {
-		if usingKubectl {
-			return "", fmt.Errorf("setting images via Chartify values files or kustomize build options is not supported when using 'kubectl kustomize'. Please set images directly in your kustomization.yaml file")
-		}
 		args := []string{"edit", "set", "image"}
 		for _, image := range kustomizeOpts.Images {
 			args = append(args, image.String())
@@ -166,9 +180,6 @@ func (r *Runner) KustomizeBuild(srcDir string, tempDir string, opts ...Kustomize
 		}
 	}
 	if kustomizeOpts.NamePrefix != "" {
-		if usingKubectl {
-			return "", fmt.Errorf("setting namePrefix via Chartify values files or kustomize build options is not supported when using 'kubectl kustomize'. Please set namePrefix directly in your kustomization.yaml file")
-		}
 		_, err := r.runInDir(tempDir, bin, "edit", "set", "nameprefix", kustomizeOpts.NamePrefix)
 		if err != nil {
 			fmt.Println(err)
@@ -176,9 +187,6 @@ func (r *Runner) KustomizeBuild(srcDir string, tempDir string, opts ...Kustomize
 		}
 	}
 	if kustomizeOpts.NameSuffix != "" {
-		if usingKubectl {
-			return "", fmt.Errorf("setting nameSuffix via Chartify values files or kustomize build options is not supported when using 'kubectl kustomize'. Please set nameSuffix directly in your kustomization.yaml file")
-		}
 		// "--" is there to avoid `namesuffix -acme` to fail due to `-a` being considered as a flag
 		_, err := r.runInDir(tempDir, bin, "edit", "set", "namesuffix", "--", kustomizeOpts.NameSuffix)
 		if err != nil {
@@ -186,9 +194,6 @@ func (r *Runner) KustomizeBuild(srcDir string, tempDir string, opts ...Kustomize
 		}
 	}
 	if kustomizeOpts.Namespace != "" {
-		if usingKubectl {
-			return "", fmt.Errorf("setting namespace via Chartify values files or kustomize build options is not supported when using 'kubectl kustomize'. Please set namespace directly in your kustomization.yaml file")
-		}
 		_, err := r.runInDir(tempDir, bin, "edit", "set", "namespace", kustomizeOpts.Namespace)
 		if err != nil {
 			return "", err
@@ -248,7 +253,11 @@ func (r *Runner) KustomizeBuild(srcDir string, tempDir string, opts ...Kustomize
 
 // kustomizeVersion returns the kustomize binary version.
 func (r *Runner) kustomizeVersion() (*semver.Version, error) {
-	versionInfo, err := r.run(nil, r.kustomizeBin(), "version")
+	bin := r.kustomizeBin()
+	if bin == "kubectl kustomize" {
+		return nil, fmt.Errorf("kustomize version detection is not available when using 'kubectl kustomize'")
+	}
+	versionInfo, err := r.run(nil, bin, "version")
 	if err != nil {
 		return nil, err
 	}

--- a/patch.go
+++ b/patch.go
@@ -192,9 +192,13 @@ resources:
 
 	renderedFileName := "all.patched.yaml"
 	renderedFile := filepath.Join(tempDir, renderedFileName)
-	r.Logf("Generating %s", renderedFile)
+	r.Logf("Generating %s", renderedFileName)
 
-	kustomizeArgs := []string{"build", tempDir, "--output", renderedFile}
+	kustomizeArgs := []string{"--output", renderedFile}
+
+	if !r.isUsingKubectlKustomize() {
+		kustomizeArgs = append([]string{"build", tempDir}, kustomizeArgs...)
+	}
 
 	if u.EnableAlphaPlugins {
 		f, err := r.kustomizeEnableAlphaPluginsFlag()

--- a/patch.go
+++ b/patch.go
@@ -198,6 +198,9 @@ resources:
 
 	if !r.isUsingKubectlKustomize() {
 		kustomizeArgs = append([]string{"build", tempDir}, kustomizeArgs...)
+	} else {
+		// kubectl kustomize does not use the "build" subcommand; pass tempDir as the target directly.
+		kustomizeArgs = append([]string{tempDir}, kustomizeArgs...)
 	}
 
 	if u.EnableAlphaPlugins {

--- a/patch.go
+++ b/patch.go
@@ -201,10 +201,7 @@ resources:
 	kustomizeArgs := []string{"--output", renderedFile}
 
 	if !usingKubectl {
-		kustomizeArgs = append([]string{"build", tempDir}, kustomizeArgs...)
-	} else {
-		// kubectl kustomize does not use the "build" subcommand; pass tempDir as the target directly.
-		kustomizeArgs = append([]string{tempDir}, kustomizeArgs...)
+		kustomizeArgs = append(kustomizeArgs, "build")
 	}
 
 	if u.EnableAlphaPlugins {
@@ -215,7 +212,8 @@ resources:
 		kustomizeArgs = append(kustomizeArgs, f)
 	}
 
-	_, err := r.run(nil, bin, kustomizeArgs...)
+	// tempDir is the kustomize target, appended last (mirrors KustomizeBuild argument order).
+	_, err := r.run(nil, bin, append(kustomizeArgs, tempDir)...)
 	if err != nil {
 		return err
 	}

--- a/patch.go
+++ b/patch.go
@@ -46,6 +46,10 @@ func (r *Runner) Patch(tempDir string, generatedManifestFiles []string, opts ...
 		}
 	}
 
+	// Resolve the kustomize binary once so PATH lookups are not repeated for every check.
+	bin := r.kustomizeBin()
+	usingKubectl := bin == "kubectl kustomize"
+
 	r.Logf("patching files: %v", generatedManifestFiles)
 
 	// Detect if CRDs originally came from templates/ directory
@@ -196,7 +200,7 @@ resources:
 
 	kustomizeArgs := []string{"--output", renderedFile}
 
-	if !r.isUsingKubectlKustomize() {
+	if !usingKubectl {
 		kustomizeArgs = append([]string{"build", tempDir}, kustomizeArgs...)
 	} else {
 		// kubectl kustomize does not use the "build" subcommand; pass tempDir as the target directly.
@@ -204,14 +208,14 @@ resources:
 	}
 
 	if u.EnableAlphaPlugins {
-		f, err := r.kustomizeEnableAlphaPluginsFlag()
+		f, err := r.kustomizeEnableAlphaPluginsFlag(usingKubectl)
 		if err != nil {
 			return err
 		}
 		kustomizeArgs = append(kustomizeArgs, f)
 	}
 
-	_, err := r.run(nil, r.kustomizeBin(), kustomizeArgs...)
+	_, err := r.run(nil, bin, kustomizeArgs...)
 	if err != nil {
 		return err
 	}

--- a/runner.go
+++ b/runner.go
@@ -108,6 +108,9 @@ func (r *Runner) kustomizeBin() string {
 	if r.KustomizeBinary != "" {
 		return r.KustomizeBinary
 	}
+	if env := os.Getenv("KUSTOMIZE_BIN"); env != "" {
+		return env
+	}
 	if _, err := exec.LookPath("kustomize"); err == nil {
 		return "kustomize"
 	}

--- a/runner.go
+++ b/runner.go
@@ -163,10 +163,10 @@ func (r *Runner) runBytes(envs map[string]string, dir, cmd string, args ...strin
 		wrappedErr := fmt.Errorf(`%w
 
 COMMAND:
- %s
+%s
 
 OUTPUT:
- %s`,
+%s`,
 			err,
 			indent(c, "  "),
 			indent(string(errBytes), "  "),

--- a/runner.go
+++ b/runner.go
@@ -108,6 +108,12 @@ func (r *Runner) kustomizeBin() string {
 	if r.KustomizeBinary != "" {
 		return r.KustomizeBinary
 	}
+	if _, err := exec.LookPath("kustomize"); err == nil {
+		return "kustomize"
+	}
+	if _, err := exec.LookPath("kubectl"); err == nil {
+		return "kubectl kustomize"
+	}
 	return "kustomize"
 }
 
@@ -140,7 +146,7 @@ func (r *Runner) runBytes(envs map[string]string, dir, cmd string, args ...strin
 
 	name := nameArgs[0]
 
-	if len(nameArgs) > 2 {
+	if len(nameArgs) > 1 {
 		a := append([]string{}, nameArgs[1:]...)
 		a = append(a, args...)
 
@@ -154,10 +160,10 @@ func (r *Runner) runBytes(envs map[string]string, dir, cmd string, args ...strin
 		wrappedErr := fmt.Errorf(`%w
 
 COMMAND:
-%s
+ %s
 
 OUTPUT:
-%s`,
+ %s`,
 			err,
 			indent(c, "  "),
 			indent(string(errBytes), "  "),

--- a/util_test.go
+++ b/util_test.go
@@ -3,11 +3,11 @@ package chartify
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHasChartLock(t *testing.T) {
@@ -159,7 +159,7 @@ func TestFindSemVerInfo(t *testing.T) {
 }
 
 func TestKustomizeBin(t *testing.T) {
-	t.Run("KustomizeBinary is set", func(t *testing.T) {
+	t.Run("KustomizeBinary option is set", func(t *testing.T) {
 		r := New(KustomizeBin("/custom/kustomize"))
 		got := r.kustomizeBin()
 		want := "/custom/kustomize"
@@ -168,25 +168,33 @@ func TestKustomizeBin(t *testing.T) {
 		}
 	})
 
-	t.Run("kustomize binary exists in PATH", func(t *testing.T) {
-		if _, err := exec.LookPath("kustomize"); err != nil {
-			t.Skip("kustomize binary not found in PATH")
+	t.Run("KUSTOMIZE_BIN environment variable", func(t *testing.T) {
+		if _, ok := os.LookupEnv("KUSTOMIZE_BIN"); ok {
+			t.Skip("KUSTOMIZE_BIN environment variable is already set")
 		}
+		os.Setenv("KUSTOMIZE_BIN", "/custom/kustomize")
+		defer os.Unsetenv("KUSTOMIZE_BIN")
 		r := New()
 		got := r.kustomizeBin()
-		want := "kustomize"
+		want := "/custom/kustomize"
 		if got != want {
 			t.Errorf("kustomizeBin() = %v, want %v", got, want)
 		}
 	})
 
 	t.Run("fallback to kubectl kustomize when kustomize not found", func(t *testing.T) {
-		if _, err := exec.LookPath("kubectl"); err != nil {
-			t.Skip("kubectl binary not found in PATH")
-		}
-		if _, err := exec.LookPath("kustomize"); err == nil {
-			t.Skip("kustomize binary found, cannot test fallback")
-		}
+		tmpDir := t.TempDir()
+		binDir := filepath.Join(tmpDir, "bin")
+		require.NoError(t, os.MkdirAll(binDir, 0755))
+
+		kubectlPath := filepath.Join(binDir, "kubectl")
+		kubectlContent := []byte("#!/bin/sh\necho 'kubectl version'\n")
+		require.NoError(t, os.WriteFile(kubectlPath, kubectlContent, 0755))
+
+		origPath := os.Getenv("PATH")
+		defer os.Setenv("PATH", origPath)
+		os.Setenv("PATH", binDir)
+
 		r := New()
 		got := r.kustomizeBin()
 		want := "kubectl kustomize"
@@ -195,18 +203,43 @@ func TestKustomizeBin(t *testing.T) {
 		}
 	})
 
-	t.Run("KUSTOMIZE_BIN environment variable", func(t *testing.T) {
-		if _, err := exec.LookPath("kustomize"); err != nil {
-			t.Skip("kustomize binary not found in PATH")
-		}
-		if _, ok := os.LookupEnv("KUSTOMIZE_BIN"); ok {
-			t.Skip("KUSTOMIZE_BIN environment variable is already set")
-		}
-		os.Setenv("KUSTOMIZE_BIN", "/custom/kustomize")
-		defer os.Unsetenv("KUSTOMIZE_BIN")
-		r := New(KustomizeBin(os.Getenv("KUSTOMIZE_BIN")))
+	t.Run("use kustomize when both kustomize and kubectl exist in PATH", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		binDir := filepath.Join(tmpDir, "bin")
+		require.NoError(t, os.MkdirAll(binDir, 0755))
+
+		kustomizePath := filepath.Join(binDir, "kustomize")
+		kustomizeContent := []byte("#!/bin/sh\necho 'kustomize version'\n")
+		require.NoError(t, os.WriteFile(kustomizePath, kustomizeContent, 0755))
+
+		kubectlPath := filepath.Join(binDir, "kubectl")
+		kubectlContent := []byte("#!/bin/sh\necho 'kubectl version'\n")
+		require.NoError(t, os.WriteFile(kubectlPath, kubectlContent, 0755))
+
+		origPath := os.Getenv("PATH")
+		defer os.Setenv("PATH", origPath)
+		os.Setenv("PATH", binDir)
+
+		r := New()
 		got := r.kustomizeBin()
-		want := "/custom/kustomize"
+		want := "kustomize"
+		if got != want {
+			t.Errorf("kustomizeBin() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("return kustomize as fallback when neither kustomize nor kubectl exist", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		binDir := filepath.Join(tmpDir, "bin")
+		require.NoError(t, os.MkdirAll(binDir, 0755))
+
+		origPath := os.Getenv("PATH")
+		defer os.Setenv("PATH", origPath)
+		os.Setenv("PATH", binDir)
+
+		r := New()
+		got := r.kustomizeBin()
+		want := "kustomize"
 		if got != want {
 			t.Errorf("kustomizeBin() = %v, want %v", got, want)
 		}

--- a/util_test.go
+++ b/util_test.go
@@ -169,11 +169,15 @@ func TestKustomizeBin(t *testing.T) {
 	})
 
 	t.Run("KUSTOMIZE_BIN environment variable", func(t *testing.T) {
-		if _, ok := os.LookupEnv("KUSTOMIZE_BIN"); ok {
-			t.Skip("KUSTOMIZE_BIN environment variable is already set")
-		}
+		origVal, hadVal := os.LookupEnv("KUSTOMIZE_BIN")
+		defer func() {
+			if hadVal {
+				os.Setenv("KUSTOMIZE_BIN", origVal)
+			} else {
+				os.Unsetenv("KUSTOMIZE_BIN")
+			}
+		}()
 		os.Setenv("KUSTOMIZE_BIN", "/custom/kustomize")
-		defer os.Unsetenv("KUSTOMIZE_BIN")
 		r := New()
 		got := r.kustomizeBin()
 		want := "/custom/kustomize"
@@ -194,6 +198,15 @@ func TestKustomizeBin(t *testing.T) {
 		origPath := os.Getenv("PATH")
 		defer os.Setenv("PATH", origPath)
 		os.Setenv("PATH", binDir)
+
+		// Ensure KUSTOMIZE_BIN does not override PATH-based lookup.
+		origKustomizeBin, hadKustomizeBin := os.LookupEnv("KUSTOMIZE_BIN")
+		defer func() {
+			if hadKustomizeBin {
+				os.Setenv("KUSTOMIZE_BIN", origKustomizeBin)
+			}
+		}()
+		os.Unsetenv("KUSTOMIZE_BIN")
 
 		r := New()
 		got := r.kustomizeBin()
@@ -220,6 +233,15 @@ func TestKustomizeBin(t *testing.T) {
 		defer os.Setenv("PATH", origPath)
 		os.Setenv("PATH", binDir)
 
+		// Ensure KUSTOMIZE_BIN does not override PATH-based lookup.
+		origKustomizeBin, hadKustomizeBin := os.LookupEnv("KUSTOMIZE_BIN")
+		defer func() {
+			if hadKustomizeBin {
+				os.Setenv("KUSTOMIZE_BIN", origKustomizeBin)
+			}
+		}()
+		os.Unsetenv("KUSTOMIZE_BIN")
+
 		r := New()
 		got := r.kustomizeBin()
 		want := "kustomize"
@@ -236,6 +258,15 @@ func TestKustomizeBin(t *testing.T) {
 		origPath := os.Getenv("PATH")
 		defer os.Setenv("PATH", origPath)
 		os.Setenv("PATH", binDir)
+
+		// Ensure KUSTOMIZE_BIN does not override PATH-based lookup.
+		origKustomizeBin, hadKustomizeBin := os.LookupEnv("KUSTOMIZE_BIN")
+		defer func() {
+			if hadKustomizeBin {
+				os.Setenv("KUSTOMIZE_BIN", origKustomizeBin)
+			}
+		}()
+		os.Unsetenv("KUSTOMIZE_BIN")
 
 		r := New()
 		got := r.kustomizeBin()

--- a/util_test.go
+++ b/util_test.go
@@ -3,6 +3,7 @@ package chartify
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -155,4 +156,59 @@ func TestFindSemVerInfo(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestKustomizeBin(t *testing.T) {
+	t.Run("KustomizeBinary is set", func(t *testing.T) {
+		r := New(KustomizeBin("/custom/kustomize"))
+		got := r.kustomizeBin()
+		want := "/custom/kustomize"
+		if got != want {
+			t.Errorf("kustomizeBin() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("kustomize binary exists in PATH", func(t *testing.T) {
+		if _, err := exec.LookPath("kustomize"); err != nil {
+			t.Skip("kustomize binary not found in PATH")
+		}
+		r := New()
+		got := r.kustomizeBin()
+		want := "kustomize"
+		if got != want {
+			t.Errorf("kustomizeBin() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("fallback to kubectl kustomize when kustomize not found", func(t *testing.T) {
+		if _, err := exec.LookPath("kubectl"); err != nil {
+			t.Skip("kubectl binary not found in PATH")
+		}
+		if _, err := exec.LookPath("kustomize"); err == nil {
+			t.Skip("kustomize binary found, cannot test fallback")
+		}
+		r := New()
+		got := r.kustomizeBin()
+		want := "kubectl kustomize"
+		if got != want {
+			t.Errorf("kustomizeBin() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("KUSTOMIZE_BIN environment variable", func(t *testing.T) {
+		if _, err := exec.LookPath("kustomize"); err != nil {
+			t.Skip("kustomize binary not found in PATH")
+		}
+		if _, ok := os.LookupEnv("KUSTOMIZE_BIN"); ok {
+			t.Skip("KUSTOMIZE_BIN environment variable is already set")
+		}
+		os.Setenv("KUSTOMIZE_BIN", "/custom/kustomize")
+		defer os.Unsetenv("KUSTOMIZE_BIN")
+		r := New(KustomizeBin(os.Getenv("KUSTOMIZE_BIN")))
+		got := r.kustomizeBin()
+		want := "/custom/kustomize"
+		if got != want {
+			t.Errorf("kustomizeBin() = %v, want %v", got, want)
+		}
+	})
 }


### PR DESCRIPTION
- [x] Review PR comments
- [x] Renamed `TestKubectlKustomizeFallback` → `TestKubectlKustomize` with a comment clarifying it tests explicit `KustomizeBin("kubectl kustomize")` behavior, not the automatic fallback (which is covered in `TestKustomizeBin`)
- [x] First subtest renamed to "KustomizeBuild succeeds with kubectl kustomize option" for clarity
- [x] All tests pass